### PR TITLE
doc/readme: should source venv before using it

### DIFF
--- a/main.py
+++ b/main.py
@@ -35,7 +35,7 @@ if not os.path.exists(database_path):
 
 @app.route("/")
 def app_index():
-    return "Hello World!"
+    return redirect('/'+NAMESPACE+'/')
 
 @app.route("/<int:item_id>")
 def app_item(item_id):

--- a/readme.md
+++ b/readme.md
@@ -20,4 +20,4 @@ To run the project, run:
 python3 main.py
 ```
 
-You can now visit `http://127.0.0.1:5000/inv/`.
+You can now visit `http://127.0.0.1:5000/`.

--- a/readme.md
+++ b/readme.md
@@ -1,14 +1,23 @@
 This is a basic Inventory system based on Flask with Python3.
 
+Installation
+===============
+
 To install the project, run:
 ```
 python3 -m venv env/
 sudo apt-get install python3-dev
+source env/bin/activate
 pip3 install -r requirements.txt
 mkdir tmp
 ```
+
+Running the application
+===============
 
 To run the project, run:
 ```
 python3 main.py
 ```
+
+You can now visit `http://127.0.0.1:5000/inv/`.


### PR DESCRIPTION
The venv needs to be activated before the dependencies can be installed
there.
Otherwise dependencies will be installed for the current user what is
usually not wanted.

Additionally adding the URL of the service to help new users finding the
right endpoint.

Signed-off-by: Chrissi^ <chris@tinyhost.de>